### PR TITLE
capture case in vahadane normalization, when all pixels are masked away

### DIFF
--- a/stainNorm_Vahadane.py
+++ b/stainNorm_Vahadane.py
@@ -28,6 +28,8 @@ def get_stain_matrix(I, threshold=0.8, lamda=0.1):
     mask = ut.notwhite_mask(I, thresh=threshold).reshape((-1,))
     OD = ut.RGB_to_OD(I).reshape((-1, 3))
     OD = OD[mask]
+    if OD.size == 0:
+        raise ValueError("all pixels have all been masked as being to bright")
     dictionary = spams.trainDL(OD.T, K=2, lambda1=lamda, mode=2, modeD=0, posAlpha=True, posD=True, verbose=False).T
     if dictionary[0, 0] < dictionary[1, 0]:
         dictionary = dictionary[[1, 0], :]


### PR DESCRIPTION
The masking in `get_stain_matrix` can result in an empty array `OD`.
This is for example when an image is very bright.

The `spams.trainDL` is then called on an empty array and fails inside some (supposedly) C code.
It is then difficult to see why the whole interpreter fails.

I therefore propose to add an assertion checking that `OD` is non-empty.
By including the `ValueError` one can then decide how to handle such cases.